### PR TITLE
fix: missing fullstop(.) in sentence

### DIFF
--- a/translations/edx-platform/conf/locale/pt_PT/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/pt_PT/LC_MESSAGES/django.po
@@ -23269,7 +23269,7 @@ msgid ""
 "Highlight important information to review later in the course or in future "
 "courses."
 msgstr ""
-"Destacar informações importantes para rever mais tarde ou em cursos futuros"
+"Destacar informações importantes para rever mais tarde ou em cursos futuros."
 
 #: lms/templates/edxnotes/edxnotes.html:82
 msgid ""


### PR DESCRIPTION
Adding missing fullstop in sentence.