### PR TITLE
fix: from my learning to my learnings

### DIFF
--- a/translations/edx-platform/conf/locale/en/LC_MESSAGES/djangojs.po
+++ b/translations/edx-platform/conf/locale/en/LC_MESSAGES/djangojs.po
@@ -10935,7 +10935,7 @@ msgid "Home"
 msgstr ""
 
 #: apps/openedx/themes/indigo/lms/static/js/DgeHeaderMenu.js
-msgid "My Learning"
+msgid "My Learnings"
 msgstr ""
 
 #: apps/openedx/themes/indigo/lms/static/js/DgeHeaderMenu.js

--- a/translations/edx-platform/conf/locale/pt_PT/LC_MESSAGES/djangojs.po
+++ b/translations/edx-platform/conf/locale/pt_PT/LC_MESSAGES/djangojs.po
@@ -11901,7 +11901,7 @@ msgid "Home"
 msgstr "Início"
 
 #: apps/openedx/themes/indigo/lms/static/js/DgeHeaderMenu.js
-msgid "My Learning"
+msgid "My Learnings"
 msgstr "As minhas Aprendizagens"
 
 #: apps/openedx/themes/indigo/lms/static/js/DgeHeaderMenu.js


### PR DESCRIPTION
- Jira Ticket: https://skilluptech.atlassian.net/browse/LJ-568
This pull request updates the translation strings for the "My Learning" menu item to use the plural form "My Learnings" in both English and Portuguese. This change ensures consistency across the user interface and improves clarity for users.

Translation updates:

* Changed the English translation key from "My Learning" to "My Learnings" in `translations/edx-platform/conf/locale/en/LC_MESSAGES/djangojs.po`.
* Changed the Portuguese translation key and value from "My Learning" to "My Learnings" and updated the translation to "As minhas Aprendizagens" in `translations/edx-platform/conf/locale/pt_PT/LC_MESSAGES/djangojs.po`.