### PR TITLE
feat(km-107): adds translation for teacher and guardian

### DIFF
--- a/translations/edx-platform/conf/locale/en/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/en/LC_MESSAGES/django.po
@@ -23822,6 +23822,6 @@ msgid "Guardian"
 msgstr "Guardian"
 
 #: themes/indigo/lms/templates/select_role.html:24
-msgid "Teacher
+msgid "Teacher"
 msgstr "Teacher"
 

--- a/translations/edx-platform/conf/locale/en/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/en/LC_MESSAGES/django.po
@@ -23825,3 +23825,4 @@ msgstr "Guardian"
 msgid "Teacher"
 msgstr "Teacher"
 
+

--- a/translations/edx-platform/conf/locale/en/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/en/LC_MESSAGES/django.po
@@ -23817,3 +23817,11 @@ msgstr "Your session will be logged out."
 msgid "Choose your role"
 msgstr "Choose your role"
 
+#: themes/indigo/lms/templates/select_role.html:23
+msgid "Guardian"
+msgstr "Guardian"
+
+#: themes/indigo/lms/templates/select_role.html:24
+msgid "Teacher
+msgstr "Teacher"
+

--- a/translations/edx-platform/conf/locale/pt_PT/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/pt_PT/LC_MESSAGES/django.po
@@ -26648,5 +26648,5 @@ msgid "Guardian"
 msgstr "Enc. de Educação"
 
 #: themes/indigo/lms/templates/select_role.html:24
-msgid "Teacher
+msgid "Teacher"
 msgstr "Professor (a)"

--- a/translations/edx-platform/conf/locale/pt_PT/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/pt_PT/LC_MESSAGES/django.po
@@ -26642,3 +26642,11 @@ msgstr "Guardar Preferências"
 #: themes/indigo/lms/templates/select_role.html:16
 msgid "Choose your role"
 msgstr "Escolhe o teu perfil"
+
+#: themes/indigo/lms/templates/select_role.html:23
+msgid "Guardian"
+msgstr "Enc. de Educação"
+
+#: themes/indigo/lms/templates/select_role.html:24
+msgid "Teacher
+msgstr "Professor (a)"

--- a/translations/edx-platform/conf/locale/pt_PT/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/pt_PT/LC_MESSAGES/django.po
@@ -26650,3 +26650,4 @@ msgstr "Enc. de Educação"
 #: themes/indigo/lms/templates/select_role.html:24
 msgid "Teacher"
 msgstr "Professor (a)"
+


### PR DESCRIPTION
## Description

Ticket - https://skilluptech.atlassian.net/browse/KM-107?atlOrigin=eyJpIjoiMDJiOGNlODIwMjMyNGVjZGE5OTM2YmY5MzcxMmNjYWMiLCJwIjoiaiJ9

- Add translation for Teacher and Guardian roles