### PR TITLE
feat: add the breadcrumbs translation to discussion mfe

### DIFF
--- a/translations/frontend-app-discussions/src/i18n/messages/pt_PT.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/pt_PT.json
@@ -1,4 +1,5 @@
 {
+  "discussions.breadcrumb.home": "Início",
   "discussions.actions.button.alt": "Menu de ações",
   "discussions.actions.copylink": "Copiar link",
   "discussions.actions.edit": "Editar",


### PR DESCRIPTION
https://skilluptech.atlassian.net/issues?filter=10054&selectedIssue=KM-504

This pull request introduces a minor update to the Portuguese translations for the discussions frontend. Specifically, it adds a translation for the "home" breadcrumb.

* Added the "Início" translation for the `discussions.breadcrumb.home` key in `pt_PT.json`.