### PR TITLE
fix: logout translations

### DIFF
--- a/translations/edx-platform/conf/locale/pt_PT/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/pt_PT/LC_MESSAGES/django.po
@@ -1107,7 +1107,7 @@ msgstr "Documentação"
 #: cms/templates/admin/base_site.html:20 lms/templates/admin/base_site.html:19
 #: wiki/templates/wiki/base.html:129
 msgid "Log out"
-msgstr "Sair"
+msgstr "Terminar sessão"
 
 #: cms/urls.py:29
 msgid "Studio Administration"


### PR DESCRIPTION
This pull request makes a minor update to the Portuguese (Portugal) translation file, changing the translation for "Log out" to use a more regionally appropriate phrase. 

- Updated the translation of "Log out" from "Sair" to "Terminar sessão" in `django.po` to better match Portuguese (Portugal) usage.