### PR TITLE
fix: add translation

### DIFF
--- a/translations/frontend-app-discussions/src/i18n/messages/pt_PT.json
+++ b/translations/frontend-app-discussions/src/i18n/messages/pt_PT.json
@@ -1,5 +1,6 @@
 {
   "discussions.breadcrumb.home": "Início",
+  "discussions.breadcrumb.discussion": "Fórum",
   "discussions.actions.button.alt": "Menu de ações",
   "discussions.actions.copylink": "Copiar link",
   "discussions.actions.edit": "Editar",


### PR DESCRIPTION
This pull request introduces a minor update to the Portuguese translations for the discussions feature by adding a new breadcrumb label.

* Translations:
  * Added the `discussions.breadcrumb.discussion` key with the value "Fórum" to the `pt_PT.json` translation file.