### PR TITLE
fix(km-610): add pt translation to course start in

### DIFF
--- a/translations/frontend-app-learning/src/i18n/messages/pt_PT.json
+++ b/translations/frontend-app-learning/src/i18n/messages/pt_PT.json
@@ -256,6 +256,7 @@
   "learning.outline.inProgress": "Em recurso",
   "learning.outline.seeMore": "Ver mais",
   "learning.outline.seeLess": "Ver menos",
+  "learning.outline.courseStartsIn": "O recurso começa em {daysLeft} dias no dia {courseDate}.",
   "learn.breadcrumb.navigation.course.home": "Recursos",
   "learn.breadcrumb.navigation.course.progress": "Progresso",
   "learn.breadcrumb.navigation.course.dates": "Datas",


### PR DESCRIPTION
## Description

Ticket - https://skilluptech.atlassian.net/browse/KM-610?atlOrigin=eyJpIjoiZGNiZTY5MDkzZmJkNDhhY2I3NTZhZTMyNTJlYWZkYmYiLCJwIjoiaiJ9

- Adds PT translation to "Course Start In" 

## Screenshot

<img width="1314" height="1061" alt="Screenshot 2026-06-24 at 15 19 39" src="https://github.com/user-attachments/assets/75437a9e-7804-4e8a-a8df-35969fb60649" />
